### PR TITLE
add partition-vec to utils

### DIFF
--- a/core/src/tesser/utils.clj
+++ b/core/src/tesser/utils.clj
@@ -173,3 +173,25 @@
        (if (reduced? ~acc)
          (let [~acc (deref ~acc)] (reduced ~expr))
          ~expr))))
+
+(defn partition-vec
+  "partitions a vector into groups of n (somewhat like partition)
+   but uses subvec for speed.
+  (partition-vec 2 [1]) => ([1])
+  (partition-vec 2 [1 2 3]) => ([1 2] [3])
+  Unlike partition, won't return empty subsequences in cases like
+  (partition-vec 2 [1])
+  Useful for supplying vectors to tesser.core/tesser."
+  ([v] (partition-vec 512 v))
+  ([^long n v]
+   (let [total-size (count v)]
+     (loop [start 0
+            end (min n total-size)
+            out (transient [])]
+     (let [curr (subvec v start end)]
+       (if (< (- end start) n)
+         (persistent! (conj! out curr))
+         (recur
+           end
+           (min (+ end n) total-size)
+           (conj! out curr))))))))

--- a/core/test/tesser/utils_test.clj
+++ b/core/test/tesser/utils_test.clj
@@ -17,3 +17,11 @@
                        (->> coll
                             differences
                             (cumulative-sums (first coll)))))))
+
+(defspec partition-vec-spec
+  test-opts
+  (prop/for-all [coll (gen/vector gen/int)]
+                (is (= coll
+                       (->> coll
+                         partition-vec
+                         flatten)))))


### PR DESCRIPTION
adds a useful function for partitioning vectors into parts suitable for
use in `tesser.core/tesser`. Uses subvec to avoid copying/allocation.
Defaults to the same chunk size clojure.core/reducers does for `fold`

This also lets users avoid the nasty edge case there is in `clojure.core/partition`,
which doesn't play well with `tesser.core/tesser`:

``` clojure
(partition 2 [1]) => ()
```
