### PR TITLE
Add support for cardinality estimation using HLL+

### DIFF
--- a/hadoop/project.clj
+++ b/hadoop/project.clj
@@ -23,4 +23,6 @@
              {:dependencies
               ; Just so we can compile our Writable
               [[org.apache.hadoop/hadoop-client "2.0.0-mr1-cdh4.3.0"
-                :exclusions [org.slf4j/slf4j-api]]]}})
+                :exclusions [org.slf4j/slf4j-api]]
+               ; for compiling without tesser.math
+               [com.clearspring.analytics/stream "2.7.0"]]}})

--- a/hadoop/src/tesser/hadoop/serialization.clj
+++ b/hadoop/src/tesser/hadoop/serialization.clj
@@ -14,7 +14,10 @@
            (org.fressian.handlers WriteHandler
                                   ReadHandler)
            (org.HdrHistogram DoubleHistogram)
-           (tesser.quantiles DualHistogram)))
+           (tesser.quantiles DualHistogram)
+           (com.clearspring.analytics.stream.cardinality
+                HyperLogLogPlus
+                HyperLogLogPlus$Builder)))
 
 ; TODO: extract serialization for math into tesser.math itself? Common
 ; interface somewhere?
@@ -229,7 +232,16 @@
             (if (pos? i)
               (recur (dec i)
                      (conj s (.readObject rdr)))
-              s)))))
+              s)))
+
+
+    HyperLogLogPlus "hyperloglogplus-estimator"
+    (write [_ w hll]
+           (write-tag! 1)
+           (.writeBytes w (.getBytes ^HyperLogLogPlus hll)))
+
+    (read [_ rdr _ _]
+          (HyperLogLogPlus$Builder/build ^bytes (.readObject rdr)))))
 
 (defn ^bytes write-byte-array
   "Dump a structure to a byte array using our handlers."

--- a/math/project.clj
+++ b/math/project.clj
@@ -6,7 +6,7 @@
 
   :dependencies [[tesser.core "1.0.0"]
 ;                 [com.tdunning/t-digest "3.0"]
-;                 [com.clearspring.analytics/stream "2.7.0"]
+                 [com.clearspring.analytics/stream "2.7.0"]
                  [org.hdrhistogram/HdrHistogram "2.1.2"]
                  [org.clojure/math.combinatorics "0.0.8"]
                  [org.clojure/math.numeric-tower "0.0.4"]]

--- a/math/project.clj
+++ b/math/project.clj
@@ -13,4 +13,4 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
                                   [org.clojars.achim/multiset "0.1.0-SNAPSHOT"]
                                   [criterium "0.4.3"]
-                                  [org.clojure/test.check "0.6.2-SNAPSHOT"]]}})
+                                  [org.clojure/test.check "0.7.0"]]}})

--- a/math/src/tesser/cardinality.clj
+++ b/math/src/tesser/cardinality.clj
@@ -1,0 +1,50 @@
+(ns tesser.cardinality
+  "Cardinality estimate digest using HyperLogLog+.
+  For examples, check tesser.math/digest."
+  (:import [com.clearspring.analytics.stream.cardinality
+            HyperLogLogPlus HyperLogLogPlus$Builder])
+  (:require [tesser.quantiles :as q]))
+
+(defn hll
+  "Construct a new HLL cardinality estimator based on the improved HyperLogLog+
+  algorithm which features sparse sets and bias correction.
+  Optionally accepts an options map with keys:
+
+  :p - Precision for the Normal set representation.
+  :sp - Precision for the Sparse set representation.
+
+  For the sparse representation:
+  :p must be a value between 4 and :sp
+  :sp must be less than 32.
+
+  For old behaviour:
+  :sp must be set to 0.
+
+  Default:
+  :p 16, :sp 0"
+  (^HyperLogLogPlus [] (hll {:p 16 :sp 0}))
+  (^HyperLogLogPlus
+   [{:keys [p sp]}]
+   {:pre [(or (zero? sp)                ;old behaviour
+              (and (<= 4 p sp)
+                   (< sp 32)))]}
+   (HyperLogLogPlus. ^int p ^int sp)))
+
+
+(extend-type HyperLogLogPlus
+  q/Digest
+  (add-point! [hll x] (doto hll (.offer x)))
+  (merge-digest! [hll ^HyperLogLogPlus other] (doto hll (.addAll other)))
+  (point-count [hll] (.cardinality hll)))
+
+
+(defn to-byte-array
+  "Convert the HLL estimator to a ByteArray"
+  ^bytes [^HyperLogLogPlus hll]
+  (.getBytes hll))
+
+
+(defn from-byte-array
+  "Convert a ByteArray into an HLL estimator instance."
+  ^HyperLogLogPlus [^bytes bs]
+  (HyperLogLogPlus$Builder/build bs))

--- a/math/src/tesser/math.clj
+++ b/math/src/tesser/math.clj
@@ -285,6 +285,23 @@
            (t/tesser [[1 2 2 3 3 3 3 3 3 3 3]]))
       ; => 3.0009765625
 
+  You may also use `tesser.cardinality/hll` for estimating the cardinality of a
+  set. HLL+ uses a probabilistic data-structure to compute set cardinality using
+  very little memory with accuracy tradeoffs.
+
+  The HLL digest can be used like the above mentioned histograms:
+
+      (def digest (->> (m/digest cardinality/hll)
+                       (t/tesser [[1 1 1 1 1 1 2 2 2 3 3 4 5]])))
+      ; => #<HyperLogLogPlus...>
+
+  Getting the cardinality out through a post-combine step:
+
+      (->> (m/digest cardinality/hll)
+           (t/post-combine #(q/point-count %))
+           (t/tesser [[1 2 2 3 3 3 3 3 3 3 3]]))
+      ; => 3
+
   I want to emphasize that depending on the size of your data, its
   distribution, and the number of digests you want to compute, you may need
   different digest algorithms and widely varying tuning parameters. Until we


### PR DESCRIPTION
### Add support for set cardinality using Hyperloglog+

    Calculate cardinality of extremely large sets in constant space (with
    tunable accuracy) using `tesser.cardinality/hll`.

    An HLL+ instance can be used with `tesser.math/digest` xform.

    HLL+ implements the Digest protocol from `tesser.quantiles`.

### Add serialization support for HyperLogLog+

    * Depends on upcoming version of `tesser.math` for xform support
    * Add an explicit provided dep for HLL lib during compilation
    * Upgrade `test.check` to latest version