### PR TITLE
Fix for Clojure 1.7.0

### DIFF
--- a/math/src/tesser/quantiles.clj
+++ b/math/src/tesser/quantiles.clj
@@ -96,13 +96,10 @@
 
   CumulativeDistribution
   (cumulative-distribution [digest]
-    (->> digest
-         .recordedValues
-         .iterator
-         iterator-seq
-         (map (fn [^DoubleHistogramIterationValue i]
-                [(.getValueIteratedTo i)
-                 (.getTotalCountToThisValue i)])))))
+    (->> (.recordedValues digest)
+         (mapv (fn [^DoubleHistogramIterationValue i]
+                 [(.getValueIteratedTo i)
+                  (.getTotalCountToThisValue i)])))))
 
 (defn hdr-histogram
   "Constructs a new HDRHistogram for doubles.


### PR DESCRIPTION
iterator-seq semantics changed a tiny bit.
See http://dev.clojure.org/jira/browse/CLJ-1738

Approach: Turn mutable iterator into a value eagerly