### PR TITLE
Fix stack overflow issue when using t/into

### DIFF
--- a/core/src/tesser/core.clj
+++ b/core/src/tesser/core.clj
@@ -743,8 +743,8 @@
    :reducer          conj
    :post-reducer     identity
    :combiner-identity vector
-   :combiner          core/concat
-   :post-combiner     (partial core/into coll)})
+   :combiner          conj
+   :post-combiner     #(core/into coll (apply concat %))})
 
 (defwraptransform post-combine
   "Transforms the output of a fold by applying a function to it.

--- a/core/test/tesser/core_test.clj
+++ b/core/test/tesser/core_test.clj
@@ -190,6 +190,16 @@
                 (is (= (sort (t/tesser chunks (t/into [])))
                        (sort (flatten1 chunks))))))
 
+(deftest into-vec-stack-overflow-regression
+  (testing (str "t/into used to have a stack overflow bug for large numbers "
+                "of chunks because of concat usage like described here: "
+                "https://stuartsierra.com/2015/04/26/clojure-donts-concat")
+    (let [n 100000]
+      (is (= (set (range n))
+             (->> (t/into [])
+                  (t/tesser (map vector (range n)))
+                  set))))))
+
 (defspec into-set-spec
   test-opts
   (prop/for-all [chunks (chunks gen/int)]


### PR DESCRIPTION
t/into used concat in a way that would cause stack overflows with large
numbers of chunks.