### PR TITLE
Avoid naming collisions between Clojure and Tesser

### DIFF
--- a/core/src/tesser/core.clj
+++ b/core/src/tesser/core.clj
@@ -35,7 +35,7 @@
       ; => 2 + 4 + 6 = 12"
   (:refer-clojure :exclude [map mapcat keep filter remove count min max range
                             frequencies into set some take empty? every?
-                            not-every? replace group-by reduce chunk])
+                            not-every? replace group-by reduce chunk bytes? update])
   (:import (java.lang Iterable))
   (:require [tesser.utils :refer :all]
             [interval-metrics.core :as metrics]

--- a/core/src/tesser/utils.clj
+++ b/core/src/tesser/utils.clj
@@ -1,5 +1,6 @@
 (ns tesser.utils
   "Toolbox."
+  (:refer-clojure :exclude [bytes? update])
   (:import (java.lang.reflect Array))
   (:require [clojure [set :as set]
                      [string :as str]


### PR DESCRIPTION
Exclude the symbols 'bytes?' and 'update' from the Clojure referral.